### PR TITLE
Fix compiling under 64 bit linux

### DIFF
--- a/btime/Makefile
+++ b/btime/Makefile
@@ -1,7 +1,7 @@
 all: compile link
 
 compile:
-	g++ -fPIC -O3 -c btime.cpp
+	g++ -fPIC -O3 -c btime.cpp -m32
 
 link:
 	g++ btime.o -O3 -m32 -lstdc++ -lrt -shared -Wl,-soname,btime.so -o btime.so


### PR DESCRIPTION
The compile command in the makefile needs -m32 tacked onto there or LD will complain:
$ make
g++ -fPIC -O3 -c btime.cpp
g++ btime.o -O3 -m32 -lstdc++ -lrt -shared -Wl,-soname,btime.so -o btime.so
/usr/bin/ld: i386:x86-64 architecture of input file `btime.o' is incompatible with i386 output
/usr/bin/ld: btime.o: file class ELFCLASS64 incompatible with ELFCLASS32
/usr/bin/ld: final link failed: File in wrong format
collect2: error: ld returned 1 exit status
